### PR TITLE
Adjust to the new API of faucet

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 let path = require("path");
 let { abort, promisify } = require("faucet-pipeline-core/lib/util");
 let FileFinder = require("faucet-pipeline-core/lib/util/files/finder");
-let imageType = require("image-type");
-let isSvg = require("is-svg");
 
 let readFile = promisify(require("fs").readFile);
 let stat = promisify(require("fs").stat);
@@ -62,7 +60,7 @@ function processFile(fileName,
 
 	return readFile(sourcePath).
 		then(content => {
-			let type = determineFileType(content);
+			let type = determineFileType(sourcePath);
 			if(type && plugins.hasOwnProperty(type)) {
 				return plugins[type](content);
 			} else {
@@ -79,21 +77,13 @@ function processFile(fileName,
 		catch(abort);
 }
 
-// TODO: Another option would be to just look at the file extension
-function determineFileType(content) {
-	let type = imageType(content);
-	if(type) {
-		return type.ext;
-	} else if(isSvg(content)) {
-		return "svg";
-	} else {
-		return false;
-	}
+function determineFileType(sourcePath) {
+	return path.extname(sourcePath).substr(1).toLowerCase();
 }
 
 // Defaults to file extensions of common image formats
 function defaultFilter(name) {
-	let extension = path.extname(name).substr(1).toLowerCase();
+	let extension = determineFileType(name);
 	return ["jpg", "jpeg", "png", "gif", "svg", "webp"].includes(extension);
 }
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ function buildMinifier(minifyConfig, assetManager, { compact }) {
 		enforceRelative: true
 	});
 	let fileFinder = new FileFinder(source, {
-		filter: minifyConfig.filter || defaultFilter
+		skipDotfiles: true,
+		filter: minifyConfig.filter
 	});
 	let { fingerprint } = minifyConfig;
 
@@ -79,12 +80,6 @@ function processFile(fileName,
 
 function determineFileType(sourcePath) {
 	return path.extname(sourcePath).substr(1).toLowerCase();
-}
-
-// Defaults to file extensions of common image formats
-function defaultFilter(name) {
-	let extension = determineFileType(name);
-	return ["jpg", "jpeg", "png", "gif", "svg", "webp"].includes(extension);
 }
 
 // Defaults to recommendation by https://images.guide for JPG, PNG and SVG

--- a/index.js
+++ b/index.js
@@ -7,23 +7,12 @@ let isSvg = require("is-svg");
 let readFile = promisify(require("fs").readFile);
 let stat = promisify(require("fs").stat);
 
-module.exports = (pluginConfig, assetManager, { watcher, compact }) => {
-	let minifyAll = buildMinifyAll(pluginConfig, assetManager, { compact });
-
-	// Run once for all files
-	minifyAll();
-
-	if(watcher) {
-		watcher.on("edit", minifyAll);
-	}
-};
-
-function buildMinifyAll(minifyConfigs, assetManager, options) {
-	let minifiers = minifyConfigs.map(minifyConfig =>
-		buildMinifier(minifyConfig, assetManager, options));
+module.exports = (pluginConfig, assetManager, { compact }) => {
+	let minifiers = pluginConfig.map(minifyConfig =>
+		buildMinifier(minifyConfig, assetManager, { compact }));
 
 	return files => minifiers.forEach(copier => copier(files));
-}
+};
 
 function buildMinifier(minifyConfig, assetManager, { compact }) {
 	let source = assetManager.resolvePath(minifyConfig.source);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 	"homepage": "http://www.faucet-pipeline.org",
 	"dependencies": {
 		"faucet-pipeline-core": "faucet-pipeline/faucet-pipeline#lord-buckethead",
-		"image-type": "^3.0.0",
 		"imagemin-mozjpeg": "^7.0.0",
 		"imagemin-pngquant": "^6.0.0",
 		"imagemin-svgo": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"homepage": "http://www.faucet-pipeline.org",
 	"dependencies": {
-		"faucet-pipeline-core": "~1.0.0-rc.10",
+		"faucet-pipeline-core": "faucet-pipeline/faucet-pipeline#lord-buckethead",
 		"image-type": "^3.0.0",
 		"imagemin-mozjpeg": "^7.0.0",
 		"imagemin-pngquant": "^6.0.0",

--- a/test/run
+++ b/test/run
@@ -20,7 +20,7 @@ function assert_smaller_size {
 
 begin "$root/test_basic"
 	faucet
-	assert_missing dist/test.txt
+	assert_identical src/test.txt dist/test.txt
 	assert_identical src/example.jpg dist/example.jpg
 	assert_identical src/example.png dist/example.png
 	assert_identical src/example.gif dist/example.gif
@@ -30,7 +30,7 @@ end
 
 begin "$root/test_basic"
 	faucet --compact
-	assert_missing dist/test.txt
+	assert_identical src/test.txt dist/test.txt
 	assert_smaller_size src/example.jpg dist/example.jpg
 	assert_smaller_size src/example.png dist/example.png
 	assert_identical src/example.gif dist/example.gif
@@ -40,7 +40,6 @@ end
 
 begin "$root/test_custom"
 	faucet --compact
-	assert_missing dist/test.txt
 	assert_missing dist/example.gif
 	assert_missing dist/example.svg
 	assert_missing dist/example.webp

--- a/test/test_basic/faucet.config.js
+++ b/test/test_basic/faucet.config.js
@@ -8,7 +8,7 @@ module.exports = {
 	}],
 	plugins: {
 		"images": {
-			package: path.resolve("../.."),
+			plugin: path.resolve("../.."),
 			bucket: "static"
 		}
 	}

--- a/test/test_basic/faucet.config.js
+++ b/test/test_basic/faucet.config.js
@@ -7,6 +7,9 @@ module.exports = {
 		target: "./dist"
 	}],
 	plugins: {
-		"images": path.resolve("../..")
+		"images": {
+			package: path.resolve("../.."),
+			bucket: "static"
+		}
 	}
 };

--- a/test/test_custom/faucet.config.js
+++ b/test/test_custom/faucet.config.js
@@ -15,7 +15,10 @@ module.exports = {
 		}
 	}],
 	plugins: {
-		"images": path.resolve("../..")
+		"images": {
+			package: path.resolve("../.."),
+			bucket: "static"
+		}
 	}
 };
 

--- a/test/test_custom/faucet.config.js
+++ b/test/test_custom/faucet.config.js
@@ -16,7 +16,7 @@ module.exports = {
 	}],
 	plugins: {
 		"images": {
-			package: path.resolve("../.."),
+			plugin: path.resolve("../.."),
 			bucket: "static"
 		}
 	}

--- a/test/test_custom/src/test.txt
+++ b/test/test_custom/src/test.txt
@@ -1,1 +1,0 @@
-Just copy me, ok?

--- a/test/test_fingerprint/faucet.config.js
+++ b/test/test_fingerprint/faucet.config.js
@@ -12,7 +12,7 @@ module.exports = {
 	}],
 	plugins: {
 		"images": {
-			package: path.resolve("../.."),
+			plugin: path.resolve("../.."),
 			bucket: "static"
 		}
 	}

--- a/test/test_fingerprint/faucet.config.js
+++ b/test/test_fingerprint/faucet.config.js
@@ -11,6 +11,9 @@ module.exports = {
 		fingerprint: false
 	}],
 	plugins: {
-		"images": path.resolve("../..")
+		"images": {
+			package: path.resolve("../.."),
+			bucket: "static"
+		}
 	}
 };


### PR DESCRIPTION
faucet-pipeline-core was the only pipeline that needed to return a promise for checking its config. I think this is not a good idea for a generic contract, so I changed this in a first step. Then I updated to the current version of faucet-pipeline-core and made the few changes that were necessary. This was foremost deleting code, and adjusting the tests to the new configuration format.